### PR TITLE
Change docker-compose for newer semantics (replacing volumes_from etc)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,27 @@
-machinery:
-    image: kerberos/machinery
-    ports:
-    - "8889"
+version: "3.5"
 
-web:
-    image: kerberos/web
-    environment:
-    - KERBEROSIO_SECURE_SSL=false
-    ports:
-    - "80"
-    volumes_from:
-    - machinery
-    links:
-    - machinery
+services:
+ machinery:
+  image: kerberos/machinery
+  ports:
+   - "8889:8889" 
+  volumes:
+   - kerberos-config:/etc/opt/kerberosio/config
+   - kerberos-capture:/etc/opt/kerberosio/capture
+   - kerberos-logs:/etc/opt/kerberosio/logs
+
+ web:
+  image: kerberos/web
+  environment:
+   - KERBEROSIO_SECURE_SSL=false
+  ports:
+   - "8080:80"
+  volumes:
+   - kerberos-config:/etc/opt/kerberosio/config
+   - kerberos-capture:/etc/opt/kerberosio/capture
+   - kerberos-logs:/etc/opt/kerberosio/logs
+
+volumes:
+ kerberos-config:
+ kerberos-capture:
+ kerberos-logs:


### PR DESCRIPTION
For using Kerberos on Docker Swarm stacks we need the usage of newer docker-compose, so we need to migrate the semantics of volumes_from to another strategy.