### PR TITLE
Add curl to use in user scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,7 +126,7 @@ FROM debian:stretch-slim
 
 COPY --chown=0:0 --from=builder /dist /
 
-RUN apt-get -y update && apt-get install -y apt-transport-https wget lsb-release && \
+RUN apt-get -y update && apt-get install -y apt-transport-https wget curl lsb-release && \
 wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg && \
 echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list && apt update -y
 


### PR DESCRIPTION
I used curl in the previous version of docker distribution (when there were two separate containers) to send messages with a photo from cam to a telegram bot.

After update to new unified docker image I've lost the possibility to use curl. I've tried to use bundled wget without any success.
